### PR TITLE
HW5 BONUS 2: UPDATES TYPE

### DIFF
--- a/scrapper/src/main/java/edu/java/dto/stackoverflow/StackOverflowUpdateDto.java
+++ b/scrapper/src/main/java/edu/java/dto/stackoverflow/StackOverflowUpdateDto.java
@@ -18,4 +18,16 @@ public class StackOverflowUpdateDto {
     @JsonProperty("owner")
     private OwnerDto owner;
 
+    @Override
+    public String toString() {
+        return String.format(
+            """
+                New updates!
+                Update time: %s,
+                Update type: %s,
+                Update actor: %s
+                """, creationDate, timelineType, owner.getLink()
+        );
+    }
+
 }

--- a/scrapper/src/test/java/edu/java/clients/StackOverflowClientTest.java
+++ b/scrapper/src/test/java/edu/java/clients/StackOverflowClientTest.java
@@ -47,8 +47,12 @@ public class StackOverflowClientTest {
             "stackoverflow.com/questions/15250928/how-to-change-springs-scheduled-fixeddelay-at-runtime").block();
         Assertions.assertEquals(1, result.size());
         Assertions.assertEquals(
-            "StackOverflowUpdateDto(creationDate=2023-12-21T00:00Z, timelineType=vote_aggregate, postId=31109486, owner=OwnerDto(accountId=93689, userId=256196, link=https://stackoverflow.com/users/256196/bohemian))",
-            result.getFirst()
+            """
+                New updates!
+                Update time: 2023-12-21T00:00Z,
+                Update type: vote_aggregate,
+                Update actor: https://stackoverflow.com/users/256196/bohemian
+                """, result.getFirst()
         );
     }
 }


### PR DESCRIPTION
Наконец добавил типы изменений по StackOverflow. По гитхабу они были всегда: https://github.com/Nypiaka/Tinkoff-project/blob/78c2a72417d47f80999045f7782f4dde145d74f5/scrapper/src/main/java/edu/java/dto/github/GitHubUpdateDto.java#L18, по StackOverflow добавил только сейчас. Из описания апи гитхаба видно, какие типы изменений будут отслеживаться, и как следствие, выводиться пользователю. Из stack overflow -  точно будут выводиться комментарии, ответы и vote up (рейтинг) сообщений. Как то так.
![Screenshot from 2024-04-23 00-04-21](https://github.com/Nypiaka/Tinkoff-project/assets/98625721/dfc913f0-3d66-4267-a6be-3d11afa5d0d8)
